### PR TITLE
Buy and Sell by productId

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ degiro.sell({
 
 #### Options
 
-Same options as [buyByProductId](#buyByProductId).
+Same options as [buyByProductId](#buybyproductid).
 
 ### searchProduct
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,34 @@ degiro.buy({
 - `price`: _number_  - Required for `limited` and `stopLimited` orders
 - `stopPrice`: _number_ - Required for `stopLoss` and `stopLimited` orders
 
+### buyByProductId
+
+This example sets a permanent buy order 10 Apple shares from NASDAQ exchange by `productId` at a fixed price of $110
+
+```javascript
+degiro.buyByProductId({
+    orderType: DeGiro.OrderTypes.limited,
+    productId: '331868',
+    timeType: DeGiro.TimeTypes.permanent,
+    size: 10,
+    price: 110,
+}).then(console.log); // prints the order id
+```
+
+#### Options
+
+- `orderType`: _number_
+    - DeGiro.OrderTypes.**limited**
+    - DeGiro.OrderTypes.**marketOrder**
+    - DeGiro.OrderTypes.**stopLoss**
+    - DeGiro.OrderTypes.**stopLimited**
+- `productId`: _string_
+- `timeType`: _number_
+    - DeGiro.TimeTypes.**day**
+    - DeGiro.TimeTypes.**permanent**
+- `price`: _number_  - Required for `limited` and `stopLimited` orders
+- `stopPrice`: _number_ - Required for `stopLoss` and `stopLimited` orders
+
 ### sell
 
 This example sets a sell order of 15 Apple shares at market price
@@ -145,9 +173,26 @@ degiro.sell({
 }).then(console.log); // prints the order id
 ```
 
+
 #### Options
 
-Same options as `buy`.
+Same options as [buy](#buy).
+
+### sellByProductId
+
+This example sets a sell order of 15 Apple shares from NASDAQ exchange at market price by its DeGiro `productId`
+
+```javascript
+degiro.sell({
+    orderType: DeGiro.OrderTypes.marketOrder,
+    productId: '331868',
+    size: 15,
+}).then(console.log); // prints the order id
+```
+
+#### Options
+
+Same options as [buyByProductId](#buyByProductId).
 
 ### searchProduct
 

--- a/src/index.js
+++ b/src/index.js
@@ -347,6 +347,35 @@ const create = (
     };
 
     /**
+     * Buy product by its id
+     *
+     * @param {number} orderType - See OrderTypes
+     * @param {string} productId - DeGiro product id
+     * @param {number} size - Number of items to buy
+     * @param {number} timeType - See TimeTypes. Defaults to TimeTypes.day
+     * @param {number} price
+     * @param {number} stopPrice
+     */
+    const buyByProductId = ({
+        orderType,
+        productId,
+        size,
+        timeType = TimeTypes.day,
+        price,
+        stopPrice,
+    }) => {
+        return checkOrder({
+            buysell: Actions.buy,
+            orderType,
+            productId: productId.toString(),
+            size,
+            timeType,
+            price,
+            stopPrice,
+        }).then(confirmOrder);
+    };
+
+    /**
      * Sell product
      *
      * @param {number} options.orderType - See OrderTypes
@@ -383,6 +412,35 @@ const create = (
     };
 
     /**
+     * Sell product
+     *
+     * @param {number} orderType - See OrderTypes
+     * @param {string} productId - DeGiro product id
+     * @param {number} size - Number of items to buy
+     * @param {number} timeType - See TimeTypes. Defaults to TimeTypes.day
+     * @param {number} price
+     * @param {number} stopPrice
+     */
+    const sellByProductId = ({
+        orderType,
+        productId,
+        size,
+        timeType = TimeTypes.day,
+        price,
+        stopPrice,
+    }) => {
+        return checkOrder({
+            buysell: Actions.sell,
+            orderType,
+            productId: productId.toString(),
+            size,
+            timeType,
+            price,
+            stopPrice,
+        }).then(confirmOrder);
+    };
+
+    /**
      * Get multiple products by its IDs
      *
      * @param {(string|string[])} ids - ID or Array of IDs of the products to query
@@ -403,7 +461,9 @@ const create = (
         login,
         searchProduct,
         buy,
+        buyByProductId,
         sell,
+        sellByProductId,
         getData,
         getCashFunds,
         getPortfolio,


### PR DESCRIPTION
Adding `buyByProductId` and `sellByProductId` functions.

Necessary mainly because:
- You can have different DeGiro products with the same `symbol` (with the actual `buy` function will pick the first one that it finds)
- You may want to save the HTTP call from the `searchProduct` if you already have the `productId`