### PR TITLE
Fix typo in size number

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ degiro
         buySell: DeGiro.Actions.sell,
         orderType: DeGiro.OrderTypes.marketOrder,
         productId: '8066561',
-        size: 15,
+        size: 5,
     })
     .then(console.log); // prints the order id
 ```


### PR DESCRIPTION
Minor typo.

> This example sets a sell order of **5** Google shares at market price

size: 15 --> 5

Thx a lot for the effort. BR Matthias